### PR TITLE
Fix branch status checks in branch rules doc

### DIFF
--- a/guide/enable-branch-rules.md
+++ b/guide/enable-branch-rules.md
@@ -62,8 +62,8 @@ The following steps will allow a repo owner/admin to set up the needed protectio
 
 Once a successful Pull Request has been created, and the `pr_build.yml` workflow has completed, require the following specific status checks:
 
-- On `develop` branch rule: `build-develop-open`
-- On `main` branch rule: `build-main-open`
+- On `develop` branch rule: `build-develop-open / build-image`
+- On `main` branch rule: `build-main-open / build-push-image`
 
 <img width="1298" alt="RequiredStatusChcecks" src="https://user-images.githubusercontent.com/6155956/195523313-350f9a34-5e64-440f-8dcc-ed4e1186f315.png">
 


### PR DESCRIPTION
The listed status checks don't actually run and prevent merging the branch after a successful run. Update to the status checks that do run.

Examples:

* https://github.com/kbase/collections/pull/676
* https://github.com/kbase/collections/pull/677