### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,1 @@
-# The owners listed will be the default owners for all code in
-# the repo. 
-
-# Order is important; the last matching pattern takes the most
-# precedence. When someone opens a pull request that only
-# modifies JS files, only @js-owner and not the global
-# owner(s) will be requested for a review.
-
-* @kkeller @bioboris @jsfillman
+@kkellerlbl @bio-boris @MrCreosote @ialarmedalien


### PR DESCRIPTION
* Update Codeowners
* Delete develop branch, since it doesn't work on .github repos
* Since the GitHub UI for reads configuration files directly from the default branch using a separate develop branch means that any changes made there won't immediately affect the UI. In other words, if you make changes in a develop branch, GitHub won't pick them up until they're merged into the default branch. This is why a develop branch isn’t practical for the .github repository—if your changes impact the GitHub UI, they must reside in the default branch.