### PR TITLE
Add SBOM attestation to all ghcr.io images. Update trivy to scan for all critical and severe cves.

### DIFF
--- a/.github/workflows/reusable_build-push.yml
+++ b/.github/workflows/reusable_build-push.yml
@@ -54,16 +54,18 @@ jobs:
                       }).join(',');
 
             - name: Build and push
-              uses: docker/build-push-action@v3
+              uses: docker/build-push-action@v5
               with:
-                  context: .
-                  file: ./Dockerfile
-                  pull: true
-                  push: true
-                  platforms: "${{ inputs.platforms }}"
-                  build-args: |
-                      BUILD_DATE=${{ steps.date.outputs.date }}
-                      VCS_REF=${{ github.sha }}
-                      BRANCH='${{ github.ref }}'
-                      TAG='${{ github.ref }}'
-                  tags: "${{ steps.tags.outputs.result }}"
+                context: .
+                file: ./Dockerfile
+                pull: true
+                push: true
+                platforms: "${{ inputs.platforms }}"
+                build-args: |
+                  BUILD_DATE=${{ steps.date.outputs.date }}
+                  VCS_REF=${{ github.sha }}
+                  BRANCH='${{ github.ref }}'
+                  TAG='${{ github.ref }}'
+                tags: "${{ steps.tags.outputs.result }}"
+                sbom: true
+

--- a/.github/workflows/reusable_build-push.yml
+++ b/.github/workflows/reusable_build-push.yml
@@ -54,7 +54,7 @@ jobs:
                       }).join(',');
 
             - name: Build and push
-              uses: docker/build-push-action@v5
+              uses: docker/build-push-action@v6
               with:
                 context: .
                 file: ./Dockerfile

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -22,7 +22,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build without push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/reusable_trivy-scans.yml
+++ b/.github/workflows/reusable_trivy-scans.yml
@@ -14,38 +14,18 @@ jobs:
                   git config --global --add safe.directory $GITHUB_WORKSPACE;
                   docker build -t trivy-test .
 
-            - name: Run Trivy vulnerability scanner, output as table
-              uses: aquasecurity/trivy-action@master
-              with:
-                  image-ref: "trivy-test"
-                  format: "table"
-                  output: "trivy-results.tbl"
-                  timeout: "20m0s"
-
-            - name: Check for log4j CVEs
-              run: |
-                  set -e
-                  for cve in CVE-2021-4104 CVE-2021-44228 CVE-2021-45046 CVE-2022-22965 ; do
-                  	if grep -c $cve trivy-results.tbl > 0;
-                  	  then
-                  	    echo "Found log4j error: $cve"
-                  	    exit 2
-                  	fi
-                  done
-                  # If above doesn't find errors, return pass message:
-                  echo "Did not find core log4j errors, yay!"
-
             - name: Rerun Trivy vulnerability scanner for GitHub security
               uses: aquasecurity/trivy-action@master
-              if: always()
               with:
                   image-ref: "trivy-test"
                   format: "sarif"
                   output: "trivy-results.sarif"
-                  timeout: "20m0s"
-                  ignore-unfixed: true
+                  timeout: "20m"
+                  ignore-unfixed: true 
+                  severity: 'CRITICAL,HIGH'
 
             - name: Upload Trivy scan results to GitHub Security tab
-              uses: github/codeql-action/upload-sarif@v2
+              uses: github/codeql-action/upload-sarif@v3
               with:
                   sarif_file: "trivy-results.sarif"
+                  category: 'trivy-docker-scan'

--- a/.github/workflows/reusable_trivy-scans.yml
+++ b/.github/workflows/reusable_trivy-scans.yml
@@ -1,31 +1,38 @@
 ---
 name: Run Trivy Scans
+
 on:
-    workflow_call:
+  workflow_call:
+
 jobs:
-    build-image:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Check out GitHub Repo
-              uses: actions/checkout@v4
+  build-and-scan-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
-            - name: Build an image from Dockerfile
-              run: |
-                  git config --global --add safe.directory $GITHUB_WORKSPACE;
-                  docker build -t trivy-test .
+    steps:
+      - name: Check out GitHub Repo
+        uses: actions/checkout@v4
 
-            - name: Rerun Trivy vulnerability scanner for GitHub security
-              uses: aquasecurity/trivy-action@master
-              with:
-                  image-ref: "trivy-test"
-                  format: "sarif"
-                  output: "trivy-results.sarif"
-                  timeout: "20m"
-                  ignore-unfixed: true 
-                  severity: 'CRITICAL,HIGH'
+      - name: Build an image from Dockerfile
+        run: |
+          docker build -t local-scan:${{ github.sha }} .
 
-            - name: Upload Trivy scan results to GitHub Security tab
-              uses: github/codeql-action/upload-sarif@v3
-              with:
-                  sarif_file: "trivy-results.sarif"
-                  category: 'trivy-docker-scan'
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: "local-scan:${{ github.sha }}"
+          format: "sarif"
+          output: "trivy-results.sarif"
+          timeout: "20m"
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        # Always run this step to upload results, even if the scan step failed
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-results.sarif"
+          category: 'trivy-docker-scan'

--- a/.github/workflows/reusable_trivy-scans.yml
+++ b/.github/workflows/reusable_trivy-scans.yml
@@ -17,17 +17,18 @@ jobs:
 
       - name: Build an image from Dockerfile
         run: |
-          docker build -t local-scan:${{ github.sha }} .
+          docker build -t kbase/trivy:scan . 
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: "local-scan:${{ github.sha }}"
+          image-ref: "kbase/trivy:scan"
           format: "sarif"
           output: "trivy-results.sarif"
           timeout: "20m"
           ignore-unfixed: true
-          severity: 'CRITICAL,HIGH'
+          severity: 'CRITICAL'
+          limit-severities-for-sarif: true
 
       - name: Upload Trivy scan results to GitHub Security tab
         # Always run this step to upload results, even if the scan step failed

--- a/.github/workflows/reusable_trivy-scans.yml
+++ b/.github/workflows/reusable_trivy-scans.yml
@@ -38,3 +38,4 @@ jobs:
           sarif_file: "trivy-results.sarif"
           category: 'trivy-docker-scan'
           ref: 'refs/heads/${{ github.base_ref }}'
+          sha: '${{ github.event.pull_request.head.sha }}'

--- a/.github/workflows/reusable_trivy-scans.yml
+++ b/.github/workflows/reusable_trivy-scans.yml
@@ -27,7 +27,7 @@ jobs:
           output: "trivy-results.sarif"
           timeout: "20m"
           ignore-unfixed: true
-          severity: 'CRITICAL'
+          severity: 'HIGH,CRITICAL'
           limit-severities-for-sarif: true
 
       - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/reusable_trivy-scans.yml
+++ b/.github/workflows/reusable_trivy-scans.yml
@@ -37,3 +37,4 @@ jobs:
         with:
           sarif_file: "trivy-results.sarif"
           category: 'trivy-docker-scan'
+          ref: 'refs/heads/${{ github.base_ref }}'


### PR DESCRIPTION
Adds SBOM attestation to all ghcr.io images.

After merging it in, all repos should automatically have this. We can trigger a PR and test it. If something bad happens, we can revert this change.


Enables trivy to scan for critical and severe vulnerabilities only, and exclude vulnerabilities that cannot be fixed with an updated.