### PR TITLE
SECURITY-7 Update Trivy

### DIFF
--- a/.github/workflows/reusable_trivy-scans.yml
+++ b/.github/workflows/reusable_trivy-scans.yml
@@ -42,12 +42,13 @@ jobs:
 
         
       - name: Upload Trivy scan results to GitHub Security tab for BASE_REF
-        # Always run this step to upload results, even if the scan step failed
-        if: always()
+        # Always run this step to upload results, even if the scan step failed,
+        # BUT ONLY if it's a pull_request event or a workflow_call from a pull_request.
+        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'workflow_call' && github.event.pull_request))
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: "trivy-results.sarif"
-          category: 'trivy-docker-scan-baseref'
+          category: 'trivy-docker-scan-base-ref'
           ref: 'refs/heads/${{ github.base_ref }}'
           sha: '${{ github.event.pull_request.head.sha }}'
 

--- a/.github/workflows/reusable_trivy-scans.yml
+++ b/.github/workflows/reusable_trivy-scans.yml
@@ -29,18 +29,19 @@ jobs:
           ignore-unfixed: true
           severity: 'HIGH,CRITICAL'
           limit-severities-for-sarif: true
+          exit-code: '1' # Fail Step if CVE of specified severity is detected 
 
 
-      # - name: Upload Trivy scan results to GitHub Security tab for PR 
-      #   # Always run this step to upload results, even if the scan step failed
-      #   if: always()
-      #   uses: github/codeql-action/upload-sarif@v3
-      #   with:
-      #     sarif_file: "trivy-results.sarif"
-      #     category: 'trivy-docker-scan'
+      - name: Upload Trivy scan results to GitHub Security tab for PR 
+        # Always run this step to upload results, even if the scan step failed
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-results.sarif"
+          category: 'trivy-docker-scan'
 
         
-      - name: Upload Trivy scan results to GitHub Security tab
+      - name: Upload Trivy scan results to GitHub Security tab for BASE_REF
         # Always run this step to upload results, even if the scan step failed
         if: always()
         uses: github/codeql-action/upload-sarif@v3
@@ -49,3 +50,23 @@ jobs:
           category: 'trivy-docker-scan'
           ref: 'refs/heads/${{ github.base_ref }}'
           sha: '${{ github.event.pull_request.head.sha }}'
+
+
+      - name: Fail on Specific Critical CVEs
+        run: |
+          set -e # Fail the script if any command exits non-zero
+          REQUIRED_CVES="CVE-2021-4104 CVE-2021-44228 CVE-2021-45046 CVE-2022-22965"
+          FOUND_CRITICAL=false
+
+          for CVE_ID in $REQUIRED_CVES; do
+            if grep -q "\"id\": \"${CVE_ID}\"" trivy-results.sarif; then
+              echo "::error file=trivy-results.sarif::CRITICAL CVE detected: ${CVE_ID}"
+              FOUND_CRITICAL=true
+            fi
+          done
+
+          if [ "$FOUND_CRITICAL" = true ]; then
+            echo "Workflow failed due to specific critical CVEs."
+            exit 1
+          fi
+        if: always() # Ensures this check runs even if previous steps had warnings/non-fatal issues

--- a/.github/workflows/reusable_trivy-scans.yml
+++ b/.github/workflows/reusable_trivy-scans.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
       security-events: write
 
-    steps:
+        steps:
       - name: Check out GitHub Repo
         uses: actions/checkout@v4
 
@@ -42,9 +42,11 @@ jobs:
 
         
       - name: Upload Trivy scan results to GitHub Security tab for BASE_REF
-        # Always run this step to upload results, even if the scan step failed,
-        # BUT ONLY if it's a pull_request event or a workflow_call from a pull_request.
-        if: always() && (github.event_name == 'pull_request' || (github.event_name == 'workflow_call' && github.event.pull_request))
+        # This step will now only run if 'always()' is true, AND
+        # if 'github.base_ref' has a value, AND
+        # if 'github.event.pull_request.head.sha' has a value.
+        # This will prevent the warning when those values are not present.
+        if: always() && github.base_ref && github.event.pull_request.head.sha
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: "trivy-results.sarif"
@@ -69,5 +71,7 @@ jobs:
           if [ "$FOUND_CRITICAL" = true ]; then
             echo "Workflow failed due to specific critical CVEs."
             exit 1
+          fi
+        if: always() # Ensures this check runs even if previous steps had warnings/non-fatal issues
           fi
         if: always() # Ensures this check runs even if previous steps had warnings/non-fatal issues

--- a/.github/workflows/reusable_trivy-scans.yml
+++ b/.github/workflows/reusable_trivy-scans.yml
@@ -73,5 +73,3 @@ jobs:
             exit 1
           fi
         if: always() # Ensures this check runs even if previous steps had warnings/non-fatal issues
-          fi
-        if: always() # Ensures this check runs even if previous steps had warnings/non-fatal issues

--- a/.github/workflows/reusable_trivy-scans.yml
+++ b/.github/workflows/reusable_trivy-scans.yml
@@ -38,7 +38,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: "trivy-results.sarif"
-          category: 'trivy-docker-scan'
+          category: 'trivy-docker-scan-pr'
 
         
       - name: Upload Trivy scan results to GitHub Security tab for BASE_REF
@@ -47,7 +47,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: "trivy-results.sarif"
-          category: 'trivy-docker-scan'
+          category: 'trivy-docker-scan-baseref'
           ref: 'refs/heads/${{ github.base_ref }}'
           sha: '${{ github.event.pull_request.head.sha }}'
 

--- a/.github/workflows/reusable_trivy-scans.yml
+++ b/.github/workflows/reusable_trivy-scans.yml
@@ -27,8 +27,8 @@ jobs:
           output: "trivy-results.sarif"
           timeout: "20m"
           ignore-unfixed: true
-          # severity: 'HIGH,CRITICAL'
-          # limit-severities-for-sarif: true
+          severity: 'HIGH,CRITICAL'
+          limit-severities-for-sarif: true
 
 
       # - name: Upload Trivy scan results to GitHub Security tab for PR 

--- a/.github/workflows/reusable_trivy-scans.yml
+++ b/.github/workflows/reusable_trivy-scans.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
       security-events: write
 
-        steps:
+      steps:
       - name: Check out GitHub Repo
         uses: actions/checkout@v4
 

--- a/.github/workflows/reusable_trivy-scans.yml
+++ b/.github/workflows/reusable_trivy-scans.yml
@@ -1,51 +1,51 @@
 ---
 name: Run Trivy Scans
+
 on:
-    workflow_call:
+  workflow_call:
+
 jobs:
-    build-image:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Check out GitHub Repo
-              uses: actions/checkout@v4
+  build-and-scan-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
-            - name: Build an image from Dockerfile
-              run: |
-                  git config --global --add safe.directory $GITHUB_WORKSPACE;
-                  docker build -t trivy-test .
+    steps:
+      - name: Check out GitHub Repo
+        uses: actions/checkout@v4
 
-            - name: Run Trivy vulnerability scanner, output as table
-              uses: aquasecurity/trivy-action@master
-              with:
-                  image-ref: "trivy-test"
-                  format: "table"
-                  output: "trivy-results.tbl"
-                  timeout: "20m0s"
+      - name: Build an image from Dockerfile
+        run: |
+          docker build -t kbase/trivy:scan . 
 
-            - name: Check for log4j CVEs
-              run: |
-                  set -e
-                  for cve in CVE-2021-4104 CVE-2021-44228 CVE-2021-45046 CVE-2022-22965 ; do
-                  	if grep -c $cve trivy-results.tbl > 0;
-                  	  then
-                  	    echo "Found log4j error: $cve"
-                  	    exit 2
-                  	fi
-                  done
-                  # If above doesn't find errors, return pass message:
-                  echo "Did not find core log4j errors, yay!"
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: "kbase/trivy:scan"
+          format: "sarif"
+          output: "trivy-results.sarif"
+          timeout: "20m"
+          ignore-unfixed: true
+          # severity: 'HIGH,CRITICAL'
+          # limit-severities-for-sarif: true
 
-            - name: Rerun Trivy vulnerability scanner for GitHub security
-              uses: aquasecurity/trivy-action@master
-              if: always()
-              with:
-                  image-ref: "trivy-test"
-                  format: "sarif"
-                  output: "trivy-results.sarif"
-                  timeout: "20m0s"
-                  ignore-unfixed: true
 
-            - name: Upload Trivy scan results to GitHub Security tab
-              uses: github/codeql-action/upload-sarif@v2
-              with:
-                  sarif_file: "trivy-results.sarif"
+      # - name: Upload Trivy scan results to GitHub Security tab for PR 
+      #   # Always run this step to upload results, even if the scan step failed
+      #   if: always()
+      #   uses: github/codeql-action/upload-sarif@v3
+      #   with:
+      #     sarif_file: "trivy-results.sarif"
+      #     category: 'trivy-docker-scan'
+
+        
+      - name: Upload Trivy scan results to GitHub Security tab
+        # Always run this step to upload results, even if the scan step failed
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-results.sarif"
+          category: 'trivy-docker-scan'
+          ref: 'refs/heads/${{ github.base_ref }}'
+          sha: '${{ github.event.pull_request.head.sha }}'

--- a/.github/workflows/reusable_trivy-scans.yml
+++ b/.github/workflows/reusable_trivy-scans.yml
@@ -1,4 +1,3 @@
----
 name: Run Trivy Scans
 
 on:
@@ -10,14 +9,13 @@ jobs:
     permissions:
       contents: read
       security-events: write
-
-      steps:
+    steps:
       - name: Check out GitHub Repo
         uses: actions/checkout@v4
 
       - name: Build an image from Dockerfile
         run: |
-          docker build -t kbase/trivy:scan . 
+          docker build -t kbase/trivy:scan .
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
@@ -29,10 +27,9 @@ jobs:
           ignore-unfixed: true
           severity: 'HIGH,CRITICAL'
           limit-severities-for-sarif: true
-          exit-code: '1' # Fail Step if CVE of specified severity is detected 
+          exit-code: '1' # Fail Step if CVE of specified severity is detected
 
-
-      - name: Upload Trivy scan results to GitHub Security tab for PR 
+      - name: Upload Trivy scan results to GitHub Security tab for PR
         # Always run this step to upload results, even if the scan step failed
         if: always()
         uses: github/codeql-action/upload-sarif@v3
@@ -40,7 +37,6 @@ jobs:
           sarif_file: "trivy-results.sarif"
           category: 'trivy-docker-scan-pr'
 
-        
       - name: Upload Trivy scan results to GitHub Security tab for BASE_REF
         # This step will now only run if 'always()' is true, AND
         # if 'github.base_ref' has a value, AND
@@ -53,7 +49,6 @@ jobs:
           category: 'trivy-docker-scan-base-ref'
           ref: 'refs/heads/${{ github.base_ref }}'
           sha: '${{ github.event.pull_request.head.sha }}'
-
 
       - name: Fail on Specific Critical CVEs
         run: |


### PR DESCRIPTION
* removed table format scan that scans/alerts for 3 cves in favor of sarif format scan
* limit severities (up for discussion)
* no longer upload for PRs (or we can make it upload to both PRs and target branches)
* Tested here
<img width="1285" alt="image" src="https://github.com/user-attachments/assets/9a246880-e46b-4ba7-9b64-af7816efe14a" />
