### PR TITLE
Update GitHub Actions to use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/reusable_build-push.yml
+++ b/.github/workflows/reusable_build-push.yml
@@ -37,8 +37,8 @@ jobs:
               uses: docker/login-action@v3
               with:
                   registry: ghcr.io
-                  username: "${{ secrets.GHCR_USERNAME }}"
-                  password: "${{ secrets.GHCR_TOKEN }}"
+                  username: "${{ github.repository_owner }}"
+                  password: "${{ secrets.GITHUB_TOKEN  }}"
 
             - name: Create github action tags from image tags
               id: tags

--- a/.github/workflows/reusable_build-push.yml
+++ b/.github/workflows/reusable_build-push.yml
@@ -41,7 +41,7 @@ jobs:
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
+                  password: ${{ github.token }}
 
             - name: Create github action tags from image tags
               id: tags

--- a/.github/workflows/reusable_build-push.yml
+++ b/.github/workflows/reusable_build-push.yml
@@ -19,6 +19,9 @@ on:
 jobs:
     build-push-image:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
         steps:
             - name: Check out GitHub Repo
               uses: actions/checkout@v4
@@ -37,8 +40,8 @@ jobs:
               uses: docker/login-action@v3
               with:
                   registry: ghcr.io
-                  username: "${{ github.repository_owner }}"
-                  password: "${{ secrets.GITHUB_TOKEN  }}"
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Create github action tags from image tags
               id: tags


### PR DESCRIPTION
* Remove need to use kbase-bot token (already removed from the repo)
* Won't need to rotate that anymore, and can be removed as as a secret.